### PR TITLE
Exporta evento como função

### DIFF
--- a/src/Events/messageCreate.js
+++ b/src/Events/messageCreate.js
@@ -1,22 +1,22 @@
-import client from "../index";
+export default (client) => {
+  client.on("messageCreate", (interaction) => {
+    try {
+      // estamos verificando se é um link
+      const url = new URL(interaction.content);
 
-client.on("messageCreate", (interaction) => {
-  try {
-    // estamos verificando se é um link
-    const url = new URL(interaction.content);
-
-    // verificamos se o usuario é do cargo que permiti mandar link no servidor
-    // eslint-disable-next-line no-underscore-dangle
-    if (url && interaction.member._roles.includes("1103837213755715654")) {
-      console.log("ola");
-    } else {
-      interaction.delete();
+      // verificamos se o usuario é do cargo que permiti mandar link no servidor
+      // eslint-disable-next-line no-underscore-dangle
+      if (url && interaction.member._roles.includes("1103837213755715654")) {
+        console.log("ola");
+      } else {
+        interaction.delete();
+      }
+    } catch (err) {
+      console.log("não é link");
     }
-  } catch (err) {
-    console.log("não é link");
-  }
 
-  if (interaction.content === "ping") {
-    interaction.reply("pong");
-  }
-});
+    if (interaction.content === "ping") {
+      interaction.reply("pong");
+    }
+  });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,11 @@ const client = new Client({
 });
 
 fs.readdir("./Events", (err, file) => {
-  file.forEach((event) => {
+  file.forEach((fileName) => {
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    require(`./Events/${event}`);
+    const { default: event } = require(`./Events/${fileName}`);
+
+    event(client);
   });
 });
 


### PR DESCRIPTION
## Mudanças

Com o objetivo de eliminar dependências circulares (cíclicas), acredito que podemos implementar os eventos como função, dessa forma evitamos esse efeito negativo e passamos ao evento suas dependências, no futuro além de cliente, ele também pode receber o cliente do banco de dados.

Mais sobre: https://spin.atomicobject.com/2018/06/25/circular-dependencies-javascript/